### PR TITLE
fix!(flux): fix store scope in screen models

### DIFF
--- a/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/Module.kt
+++ b/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/Module.kt
@@ -12,7 +12,7 @@ import org.kodein.di.delegate
 internal fun bluebellDomain() = DI.Module(name = "Bluebell Domain") {
 
     bindSingleton { Flux(FluxDispatcher()) }
-
+    
     delegate<Dispatcher>().to<Flux>()
 
     bindProviderOf(::FormatDateTimeUseCase)

--- a/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/arch/Store.kt
+++ b/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/arch/Store.kt
@@ -1,5 +1,7 @@
 package com.micrantha.bluebell.domain.arch
 
+import kotlinx.coroutines.CoroutineScope
+
 interface Action
 
 fun interface ReducerStore<State> {
@@ -21,5 +23,5 @@ interface Store<State> : Stateful<State>, ReducerStore<State>, EffectedStore<Sta
 }
 
 interface StoreFactory {
-    fun <T> createStore(state: T): Store<T>
+    fun <T> createStore(initialState: T, scope: CoroutineScope): Store<T>
 }

--- a/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/flux/Flux.kt
+++ b/shared/src/commonMain/kotlin/com/micrantha/bluebell/domain/flux/Flux.kt
@@ -3,11 +3,12 @@ package com.micrantha.bluebell.domain.flux
 import com.micrantha.bluebell.domain.arch.Dispatcher
 import com.micrantha.bluebell.domain.arch.Store
 import com.micrantha.bluebell.domain.arch.StoreFactory
+import kotlinx.coroutines.CoroutineScope
 
 class Flux(
     private val dispatcher: FluxDispatcher
 ) : StoreFactory, Dispatcher by dispatcher {
 
-    override fun <T> createStore(state: T): Store<T> =
-        FluxStore(state).apply { dispatcher.register(this::dispatch) }
+    override fun <T> createStore(initialState: T, scope: CoroutineScope): Store<T> =
+        FluxStore(initialState, scope).apply { dispatcher.register(this::dispatch) }
 }


### PR DESCRIPTION
- effects can linger with default scope, must tie to screen model to dispose of when screen model is navigated away from